### PR TITLE
add heap addon and make sail read .sym files from multiple directorys including any addon with a syms directory for Japanese Cat Onomatopoeia Loader

### DIFF
--- a/addons/Heap/CMakeLists.txt
+++ b/addons/Heap/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+
+include_directories(include)
+set(SOURCES
+    src/hk/heap.cpp
+)
+add_library(Heap ${SOURCES})
+
+include(../../../config/config.cmake)
+include(../../cmake/apply_config.cmake)
+
+apply_config(Heap)
+
+target_compile_definitions(Heap PRIVATE)
+target_include_directories(Heap PRIVATE include/hk ${CMAKE_CURRENT_BINARY_DIR})
+
+set(ROOTDIR ${CMAKE_CURRENT_SOURCE_DIR}/../../)

--- a/addons/Heap/include/hk/heap/heap.h
+++ b/addons/Heap/include/hk/heap/heap.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "hk/heap/lmem.h"
+
+namespace hk::heap {
+    using HeapHandle = nn::lmem::detail::HeapHead*;
+    extern HeapHandle MainHeap;
+    void initHeap();
+}
+
+extern "C" { 
+    void* malloc(size_t size); 
+    void free(void* ptr); 
+    void* aligned_alloc(size_t alignment, size_t size);
+};

--- a/addons/Heap/include/hk/heap/lmem.h
+++ b/addons/Heap/include/hk/heap/lmem.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <hk/types.h>
+
+namespace nn::lmem {
+    namespace detail {
+        struct HeapHead;
+    }
+
+    enum AllocationMode {
+        AllocationMode_FirstFit,
+        AllocationMode_BestFit,
+    };
+
+    using HeapHandle = detail::HeapHead*;
+
+    HeapHandle CreateExpHeap(void* address, size_t size, int option);
+    void DestroyExpHeap(HeapHandle handle);
+    void* AllocateFromExpHeap(HeapHandle handle, size_t size, int alignment);
+    void FreeToExpHeap(HeapHandle handle, void* ptr);
+    size_t GetExpHeapAllocatableSize(HeapHandle handle, int alignment);
+    size_t GetExpHeapTotalFreeSize(HeapHandle handle);
+    size_t GetExpHeapBlockSize(const void* ptr);
+    AllocationMode GetExpHeapAllocationMode(HeapHandle handle);
+    AllocationMode SetExpHeapAllocationMode(HeapHandle handle, AllocationMode new_mode);
+}

--- a/addons/Heap/src/hk/heap.cpp
+++ b/addons/Heap/src/hk/heap.cpp
@@ -1,0 +1,44 @@
+#include "hk/heap/heap.h"
+#include "hk/util/Context.h"
+
+#ifndef FAKE_HEAP_SIZE
+#define FAKE_HEAP_SIZE 0x5000
+#endif
+
+namespace hk::heap {
+    char __fake_heap[FAKE_HEAP_SIZE];
+    char* fake_heap_start = __fake_heap;
+    char* fake_heap_end = __fake_heap + FAKE_HEAP_SIZE;
+
+    HeapHandle MainHeap = nullptr;
+
+    void initHeap() {
+        using create_signature = HeapHandle (*)(void*, size_t, int);
+        create_signature create_heap = (create_signature)hk::util::lookupSymbol<"_ZN2nn4lmem13CreateExpHeapEPvmi">(); 
+        MainHeap = create_heap(__fake_heap, FAKE_HEAP_SIZE, 4);
+    }
+}
+
+extern "C" { 
+    void* malloc(size_t size) { 
+        using alloc_signature = void* (*)(nn::lmem::detail::HeapHead*, size_t, int);
+        alloc_signature alloc_heap = (alloc_signature)hk::util::lookupSymbol<"_ZN2nn4lmem19AllocateFromExpHeapEPNS0_6detail8HeapHeadEm">();
+        void* allocated = alloc_heap(hk::heap::MainHeap, size, 8); 
+        return allocated;
+    }
+    void free(void* ptr) {
+        using free_signature = void* (*)(nn::lmem::detail::HeapHead*, void*);
+        free_signature free_heap = (free_signature)hk::util::lookupSymbol<"_ZN2nn4lmem13FreeToExpHeapEPNS0_6detail8HeapHeadEPv">();
+        free_heap(hk::heap::MainHeap, ptr); 
+    } 
+    void* aligned_alloc(size_t alignment, size_t size) { 
+        using alloc_signature = void* (*)(nn::lmem::detail::HeapHead*, size_t, int);
+        alloc_signature alloc_heap = (alloc_signature)hk::util::lookupSymbol<"_ZN2nn4lmem19AllocateFromExpHeapEPNS0_6detail8HeapHeadEm">();
+        void* allocated = alloc_heap(hk::heap::MainHeap, size, alignment); 
+        return allocated; 
+    }
+}; 
+
+//main heap 
+void* operator new(size_t size) { return malloc(size); }
+void operator delete(void* ptr) { free(ptr); }

--- a/addons/Heap/syms/sdk.sym
+++ b/addons/Heap/syms/sdk.sym
@@ -1,0 +1,4 @@
+@sdk
+_ZN2nn4lmem13CreateExpHeapEPvmi
+_ZN2nn4lmem19AllocateFromExpHeapEPNS0_6detail8HeapHeadEm
+_ZN2nn4lmem13FreeToExpHeapEPNS0_6detail8HeapHeadEPv

--- a/cmake/sail.cmake
+++ b/cmake/sail.cmake
@@ -15,7 +15,7 @@ function (usesail lib)
             message(FATAL_ERROR "Sail binary not found! Did you run setup_sail.py?")
         endif()
 
-        file(GLOB_RECURSE SYM_FILES ${CMAKE_CURRENT_SOURCE_DIR}/syms/*.sym)
+        file(GLOB_RECURSE SYM_FILES ${CMAKE_CURRENT_SOURCE_DIR}/syms/*.sym ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms/*.sym)
 
         set(SYMDEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/config/ModuleList.sym")
         set(SYMDEPENDS "${SYMDEPENDS};${CMAKE_CURRENT_SOURCE_DIR}/config/VersionList.sym")
@@ -28,7 +28,7 @@ function (usesail lib)
         watch(${lib} ${SYMDEPENDS})
 
         add_custom_command(TARGET ${lib} PRE_LINK
-            COMMAND ${SAIL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/config/ModuleList.sym ${CMAKE_CURRENT_SOURCE_DIR}/config/VersionList.sym ${CMAKE_CURRENT_SOURCE_DIR}/syms ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_ASM_COMPILER} $<IF:$<BOOL:${IS_32_BIT}>,1,0>
+            COMMAND ${SAIL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/config/ModuleList.sym ${CMAKE_CURRENT_SOURCE_DIR}/config/VersionList.sym ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_ASM_COMPILER} $<IF:$<BOOL:${IS_32_BIT}>,1,0> ${CMAKE_CURRENT_SOURCE_DIR}/syms ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms
         )
     endif()
 endfunction()

--- a/hakkun/sail/src/main.cpp
+++ b/hakkun/sail/src/main.cpp
@@ -5,15 +5,19 @@
 #include <filesystem>
 
 int main(int argc, char* argv[]) {
-    if (argc != 7)
-        sail::fail<1>("%s <ModuleList> <VersionList> <SymbolTraversePath> <OutFolder> <ClangBinary> <Is32Bit>\n", argv[0]);
+    if (argc < 7)
+        sail::fail<1>("%s <ModuleList> <VersionList> <OutFolder> <ClangBinary> <Is32Bit> <SymbolTraversePaths>\n", argv[0]);
 
     const char* moduleListPath = argv[1];
     const char* versionListPath = argv[2];
-    const char* symbolTraversePath = argv[3];
-    const char* outFolder = argv[4];
-    const char* clangBinary = argv[5];
-    sail::is32Bit() = argc == 7 && std::string(argv[6]) == "1";
+    const char* outFolder = argv[3];
+    const char* clangBinary = argv[4];
+    sail::is32Bit() = std::string(argv[5]) == "1";
+    std::vector<const char*> symbolTraversePaths;
+    for (int i = 6; i < argc; i++) {
+        symbolTraversePaths.push_back(argv[i]);
+    }
+
 
     sail::loadConfig(moduleListPath, versionListPath);
 
@@ -21,17 +25,19 @@ int main(int argc, char* argv[]) {
 
     std::vector<sail::Symbol> symbols;
 
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(symbolTraversePath)) {
-        if (!entry.path().string().ends_with(".sym"))
-            continue;
+    for (auto i : symbolTraversePaths) {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(i)) {
+            if (!entry.path().string().ends_with(".sym"))
+                continue;
 
-        const char* path = entry.path().c_str();
+            const char* path = entry.path().c_str();
 
-        std::string data = sail::readFileString(path);
-        auto syms = sail::parseSymbolFile(data, path);
+            std::string data = sail::readFileString(path);
+            auto syms = sail::parseSymbolFile(data, path);
 
-        for (const auto& sym : syms)
-            symbols.push_back(sym);
+            for (const auto& sym : syms)
+                symbols.push_back(sym);
+        }
     }
 
     printf("-- Generating symbols\n");


### PR DESCRIPTION
I am 99% sure this works but not 100% like the heap shit worked in super beat blocks but and when I moved the symbols from like the normal path to the addon path it worked but you might want to rizz through the code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/7)
<!-- Reviewable:end -->
