### PR TITLE
fix rtld module header

### DIFF
--- a/hakkun/src/hk/init/module.S
+++ b/hakkun/src/hk/init/module.S
@@ -4,8 +4,11 @@
 
 .section ".text.modulestart","a"
 __module_start__:
-    b __module_entry__
+    b __module_entrypoint__
     .word __mod0 - __module_start__
+
+__module_entrypoint__:
+    b __module_entry__
 
 .section ".rodata.mod0","a"
 .align 2


### PR DESCRIPTION
This fixes crashes when doing things such as calling nn::diag::GetRequiredBufferSizeForGetAllModuleInfo()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/23)
<!-- Reviewable:end -->
