### PR TITLE
sail: fix std::filesystem::path::c_str() type on Windows

### DIFF
--- a/sail/src/main.cpp
+++ b/sail/src/main.cpp
@@ -33,7 +33,11 @@ int main(int argc, char* argv[]) {
             if (!entry.path().string().ends_with(".sym"))
                 continue;
 
-            const char* path = entry.path().c_str();
+            // std::filesystem::path::value_type is wchar_t on Windows, so
+            // entry.path().c_str() yields wchar_t*. Convert via .string() to
+            // a UTF-8 std::string before taking a C pointer.
+            const std::string pathStr = entry.path().string();
+            const char* path = pathStr.c_str();
 
             std::string data = sail::readFileString(path);
             auto syms = sail::parseSymbolFile(data, path);

--- a/sail/src/main.cpp
+++ b/sail/src/main.cpp
@@ -33,9 +33,6 @@ int main(int argc, char* argv[]) {
             if (!entry.path().string().ends_with(".sym"))
                 continue;
 
-            // std::filesystem::path::value_type is wchar_t on Windows, so
-            // entry.path().c_str() yields wchar_t*. Convert via .string() to
-            // a UTF-8 std::string before taking a C pointer.
             const std::string pathStr = entry.path().string();
             const char* path = pathStr.c_str();
 


### PR DESCRIPTION
## Summary

- `std::filesystem::path::value_type` is `wchar_t` on Windows and `char` on POSIX, so `entry.path().c_str()` returns `const wchar_t*` on Windows.
- The code in `sail/src/main.cpp` assigns it to `const char*` and passes it to `readFileString` / `parseSymbolFile`, which fails to compile on MSVC and produces a mangled (UTF-16-as-bytes) path with clang on Windows.
- The portable fix is `entry.path().string()`, which materializes a UTF-8 `std::string` on both platforms. The local then holds the string by value so the `c_str()` pointer stays valid.
- Behavior on POSIX is unchanged — `string()` on a path whose `value_type` is already `char` is just a copy of the native representation.

## Test plan

- [x] Linux build still compiles and produces the same `sail` binary behavior.
- [x] Windows build (mingw64 g++ via msys2) now compiles where it previously errored with a `wchar_t* -> char*` conversion failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/72)
<!-- Reviewable:end -->
