### PR TITLE
sail: quote clangBinary in popen command line

### DIFF
--- a/sail/src/fakelib.cpp
+++ b/sail/src/fakelib.cpp
@@ -10,9 +10,7 @@
 
 namespace sail {
     static void compile(const char* outPath, const char* clangBinary, const char* language, const std::string& source, const std::string& flags, const char* filename) {
-        // Quote clangBinary so popen() handles paths with spaces (common on
-        // Windows: "C:\Program Files\LLVM\bin\clang.exe"). Without quoting,
-        // the shell parses "C:\Program" as the command and the rest as args.
+        // Quote clangBinary so popen() handles paths with spaces
         std::string cmd;
         cmd.push_back('"');
         cmd.append(clangBinary);

--- a/sail/src/fakelib.cpp
+++ b/sail/src/fakelib.cpp
@@ -10,7 +10,13 @@
 
 namespace sail {
     static void compile(const char* outPath, const char* clangBinary, const char* language, const std::string& source, const std::string& flags, const char* filename) {
-        std::string cmd = clangBinary;
+        // Quote clangBinary so popen() handles paths with spaces (common on
+        // Windows: "C:\Program Files\LLVM\bin\clang.exe"). Without quoting,
+        // the shell parses "C:\Program" as the command and the rest as args.
+        std::string cmd;
+        cmd.push_back('"');
+        cmd.append(clangBinary);
+        cmd.push_back('"');
 
         if (is32Bit()) {
             cmd.append(" --target=armv7a-none-eabi -march=armv7-a");


### PR DESCRIPTION
## Summary

- `fakelib.cpp::compile` builds a `popen()` command line that starts with the path to the host clang. The current code does `std::string cmd = clangBinary;` (unquoted).
- On Windows, the standard LLVM install path is `C:\Program Files\LLVM\bin\clang.exe`. With the unquoted form the shell parses `C:\Program` as the command and the rest as args — sail then bails out with "pipe fail" / "clang compilation failed" with no clue why.
- Wrapping `clangBinary` in double quotes keeps the path as a single token regardless of internal spaces. POSIX behavior is unchanged (double-quoting a no-space token is a no-op).

## Test plan

- [x] Linux build: behavior unchanged, sail still produces the fakelib successfully.
- [x] Windows build with clang at `C:\Program Files\LLVM\bin\clang.exe`: sail now succeeds where it previously failed at `popen`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/73)
<!-- Reviewable:end -->
