### PR TITLE
sail.cmake: expand addons/*/syms glob at configure time

### DIFF
--- a/cmake/sail.cmake
+++ b/cmake/sail.cmake
@@ -40,7 +40,21 @@ function (usesail lib)
         
         file(GLOB_RECURSE ADDONS_SYMS_EMPTY_TEST ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms/*.sym)
         if (ADDONS_SYMS_EMPTY_TEST)
-            set(SAIL_CMD ${SAIL_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms)
+            # Expand the glob ourselves rather than passing a literal pattern.
+            # On POSIX, /bin/sh expands the wildcard before sail sees it, so
+            # the original `.../sys/addons/*/syms` form happens to work. On
+            # Windows, add_custom_command(COMMAND ...) invokes the command
+            # directly (no shell glob), and sail receives the literal string
+            # "...sys/addons/*/syms" which doesn't exist — recursive_directory_iterator
+            # then throws and sail aborts. Expand at configure time so both
+            # platforms hand sail real directory paths.
+            file(GLOB ADDONS_SYM_DIRS LIST_DIRECTORIES TRUE
+                 ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms)
+            foreach (d IN LISTS ADDONS_SYM_DIRS)
+                if (IS_DIRECTORY ${d})
+                    set(SAIL_CMD ${SAIL_CMD} ${d})
+                endif()
+            endforeach()
         endif()
         
         add_custom_command(TARGET ${lib} PRE_LINK

--- a/cmake/sail.cmake
+++ b/cmake/sail.cmake
@@ -40,21 +40,9 @@ function (usesail lib)
         
         file(GLOB_RECURSE ADDONS_SYMS_EMPTY_TEST ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms/*.sym)
         if (ADDONS_SYMS_EMPTY_TEST)
-            # Expand the glob ourselves rather than passing a literal pattern.
-            # On POSIX, /bin/sh expands the wildcard before sail sees it, so
-            # the original `.../sys/addons/*/syms` form happens to work. On
-            # Windows, add_custom_command(COMMAND ...) invokes the command
-            # directly (no shell glob), and sail receives the literal string
-            # "...sys/addons/*/syms" which doesn't exist — recursive_directory_iterator
-            # then throws and sail aborts. Expand at configure time so both
-            # platforms hand sail real directory paths.
             file(GLOB ADDONS_SYM_DIRS LIST_DIRECTORIES TRUE
                  ${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms)
-            foreach (d IN LISTS ADDONS_SYM_DIRS)
-                if (IS_DIRECTORY ${d})
-                    set(SAIL_CMD ${SAIL_CMD} ${d})
-                endif()
-            endforeach()
+            set(SAIL_CMD ${SAIL_CMD} ${ADDONS_SYM_DIRS})
         endif()
         
         add_custom_command(TARGET ${lib} PRE_LINK


### PR DESCRIPTION
## Summary

- `usesail` appends `${CMAKE_CURRENT_SOURCE_DIR}/sys/addons/*/syms` as a literal token to `SAIL_CMD`, then runs it via `add_custom_command(... COMMAND ${SAIL_CMD})`.
- `add_custom_command` runs the command directly without going through a shell. On POSIX this happens to work because /bin/sh (or whatever ninja delegates to for the invocation) expands the wildcard before sail sees it; on Windows the literal `*` is passed through, and sail's `recursive_directory_iterator` throws on a non-existent path.
- Expand the glob at configure time via `file(GLOB)` and append each real directory. The existing `ADDONS_SYMS_EMPTY_TEST` guard still handles the no-addons case.
- POSIX behavior is preserved: sail gets the same set of directory paths it would have received via shell expansion.

## Test plan

- [x] Linux build with addon `syms/` directories: sail still receives the same directory list.
- [x] Linux build with no addons: short-circuits via `ADDONS_SYMS_EMPTY_TEST` exactly as before.
- [x] Windows build: sail no longer aborts on the literal `*` path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/74)
<!-- Reviewable:end -->
