### PR TITLE
generate_exefs: invoke elf2nso.py via explicit `python`

### DIFF
--- a/cmake/generate_exefs.cmake
+++ b/cmake/generate_exefs.cmake
@@ -13,12 +13,12 @@ function(generate_exefs)
 
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E echo "-- Generating ${PROJECT_NAME}.nso"
-            COMMAND ${PROJECT_SOURCE_DIR}/sys/tools/elf2nso.py ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}.baked ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.nso -c
+            COMMAND python ${PROJECT_SOURCE_DIR}/sys/tools/elf2nso.py ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}.baked ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.nso -c
         )
     else()
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E echo "-- Generating ${PROJECT_NAME}.nso"
-            COMMAND ${PROJECT_SOURCE_DIR}/sys/tools/elf2nso.py ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.nso -c
+            COMMAND python ${PROJECT_SOURCE_DIR}/sys/tools/elf2nso.py ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.nso -c
         )
     endif()
 endfunction()


### PR DESCRIPTION
## Summary

- The two `elf2nso.py` invocations in `generate_exefs.cmake` are the only tool calls in the file (and the wider build) that don't prefix `python`. The other tools (`build_npdm.py`, `bake_hashes.py`) all use `COMMAND python <script>`.
- On POSIX the script's shebang + executable bit make the bare form work. On Windows scripts don't carry an executable bit and the shebang isn't honored — `add_custom_command` tries to execute the `.py` directly, which Windows resolves via file-association lookup (py.exe or nothing).
- Prefixing `python` makes both lines consistent with the rest of the file and removes the Windows-only failure mode. POSIX behavior is unchanged (interpreter invoked explicitly instead of via shebang).

## Test plan

- [x] Linux build: still produces `.nso` from both the baked and non-baked paths.
- [x] Windows build: post-build step no longer fails to launch the script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/75)
<!-- Reviewable:end -->
