### PR TITLE
Fix reallocate behavior

### DIFF
--- a/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
+++ b/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
@@ -33,6 +33,8 @@ namespace hk::mem {
     }
 
     void* ExpHeap::reallocate(void* oldPtr, size size) {
+        if (!oldPtr)
+            return allocate(size)
         auto resizedSize = ams::lmem::ResizeExpHeapMemoryBlock(getHeapHandle(), oldPtr, size);
         if (resizedSize > 0)
             return oldPtr;

--- a/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
+++ b/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
@@ -33,7 +33,7 @@ namespace hk::mem {
     }
 
     void* ExpHeap::reallocate(void* oldPtr, size size) {
-        if (!oldPtr)
+        if (oldPtr == nullptr)
             return allocate(size)
         auto resizedSize = ams::lmem::ResizeExpHeapMemoryBlock(getHeapHandle(), oldPtr, size);
         if (resizedSize > 0)


### PR DESCRIPTION
To quote the [`realloc` docs](https://man7.org/linux/man-pages/man3/realloc.3p.html):

> If ptr is a null pointer, realloc() shall be equivalent to
> malloc() for the specified size.

With the existing behavior, calling `realloc(nullptr, size)` will cause an assertion failure in `ams::lmem::impl::ResizeExpHeapMemoryBlock` on `HK_ASSERT(IsValidUsedMemoryBlock(handle, mem_block))`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/80)
<!-- Reviewable:end -->
