### PR TITLE
Add missing semicolon in ExpHeap addon

### DIFF
--- a/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
+++ b/addons/ExpHeap/src/hk/mem/ExpHeap.cpp
@@ -34,7 +34,7 @@ namespace hk::mem {
 
     void* ExpHeap::reallocate(void* oldPtr, size size) {
         if (oldPtr == nullptr)
-            return allocate(size)
+            return allocate(size);
         auto resizedSize = ams::lmem::ResizeExpHeapMemoryBlock(getHeapHandle(), oldPtr, size);
         if (resizedSize > 0)
             return oldPtr;


### PR DESCRIPTION
epic fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/82)
<!-- Reviewable:end -->
