### PR TITLE
`core`: fix mismatching function signature for non-NNSDK builds

### DIFF
--- a/hakkun/core/src/hk/diag/diag.cpp
+++ b/hakkun/core/src/hk/diag/diag.cpp
@@ -190,9 +190,9 @@ File: %s:%u:%u
             svc::Break(reason, &abortResult, sizeof(abortResult));
     }
 #else
-    hk_noreturn void abortImpl(Result result, const char* file, int line, const char* msgFmt, std::va_list arg) {
+    hk_noreturn void abortImpl(Result result, const char* file, u32 line, u16 column, const char* msgFmt, std::va_list arg) {
 #if !defined(HK_RELEASE) or defined(HK_RELEASE_DEBINFO)
-        log(cAbortFormat, file, line);
+        log(cAbortFormat, file, line, column);
         logLineImpl(msgFmt, arg);
         dumpResultTrace(result);
 #endif


### PR DESCRIPTION
it seems like when the function signature of `diag::abortImpl` was changed to include `u16 column`, the version of it that gets built when `NNSDK` is not set didn't get that change, so `AddResultName` wasn't getting the function it expected. this fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fruityloops1/LibHakkun/86)
<!-- Reviewable:end -->
